### PR TITLE
Add Complex type support for Send/Recv

### DIFF
--- a/src/base.jl
+++ b/src/base.jl
@@ -53,3 +53,17 @@ ncclDataType_t(::Type{UInt64}) = ncclUint64
 ncclDataType_t(::Type{Float16}) = ncclFloat16
 ncclDataType_t(::Type{Float32}) = ncclFloat32
 ncclDataType_t(::Type{Float64}) = ncclFloat64
+
+# Complex types: map to their real component type (count must be doubled by caller)
+ncclDataType_t(::Type{Complex{Float16}}) = ncclFloat16
+ncclDataType_t(::Type{Complex{Float32}}) = ncclFloat32
+ncclDataType_t(::Type{Complex{Float64}}) = ncclFloat64
+
+"""
+    nccl_count(buf)
+
+Return the element count to pass to NCCL for `buf`. For Complex arrays,
+this is `2 * length(buf)` since NCCL treats them as pairs of real values.
+"""
+nccl_count(buf) = length(buf)
+nccl_count(buf::AbstractArray{<:Complex}) = 2 * length(buf)

--- a/src/pointtopoint.jl
+++ b/src/pointtopoint.jl
@@ -13,7 +13,7 @@ called.
 """
 function Send(sendbuf, comm::Communicator; dest::Integer,
               stream::CuStream=default_device_stream(comm))
-    count = length(sendbuf)
+    count = nccl_count(sendbuf)
     datatype = ncclDataType_t(eltype(sendbuf))
     ncclSend(sendbuf, count, datatype, dest, comm, stream)
     return nothing
@@ -34,7 +34,7 @@ Write the data from a matching [`Send`](@ref) on rank `source` into `recvbuf`.
 """
 function Recv!(recvbuf, comm::Communicator; source::Integer,
                stream::CuStream=default_device_stream(comm))
-    count = length(recvbuf)
+    count = nccl_count(recvbuf)
     datatype = ncclDataType_t(eltype(recvbuf))
     ncclRecv(recvbuf, count, datatype, source, comm, stream)
     return recvbuf.data


### PR DESCRIPTION
## Summary

- Add `ncclDataType_t` mappings for `Complex{Float16/32/64}` that return the real component type
- Add `nccl_count(buf)` helper that returns `2 * length(buf)` for Complex arrays
- `Send` and `Recv!` now use `nccl_count()` so Complex CuArrays work transparently

## Motivation

Distributed FFT solvers operate on `Complex{Float32}` buffers. Without this change, passing a `CuArray{ComplexF32}` to `NCCL.Send` throws `MethodError: no method matching ncclDataType_t(::Type{ComplexF32})`.

The fix maps Complex types to their real component type and doubles the element count, which is correct since `Complex{T}` is stored as two contiguous `T` values in memory.

## Test plan

- [x] `ncclDataType_t(Complex{Float32}) === ncclFloat32`
- [x] `nccl_count(zeros(Complex{Float32}, 10)) == 20`
- [x] Send/Recv of `CuArray{ComplexF32}` between GPUs produces correct results
- [x] Used successfully in NCCL-based distributed FFT solver (Oceananigans.jl)

🤖 Generated with [Claude Code](https://claude.com/claude-code)